### PR TITLE
made mpad url distributor-neutral

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,10 @@ The authorization flow depends on the `mpad.js` browser library. To show the log
 (authorization URL) and `data-element` (login button ID)
 
 ```
-<script src="https://dd.cdn.mpin.io/mpad/mpad.js" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
+<script src="<<Insert correct mpad url here>>" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
 ```
+
+Please refer to your distributor-specific documentation to find the correct url for the mpad.js `script src`
 
 After user
 interaction with the login button the user will be sent to the `redirect_uri` defined at

--- a/samples/templates/index.html
+++ b/samples/templates/index.html
@@ -81,8 +81,10 @@
             {% endif %}
         </div>
     {% endif %}
+
+<!--Please refer to your distributor-specific documentation to find the correct url for the mpad.js script src-->
     {% if auth_url %}
-        <script src="https://dd.cdn.mpin.io/mpad/mpad.js" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
+        <script src="<<Insert correct mpad url here>>" data-authurl="{{ auth_url }}" data-element="btmpin"></script>
     {% endif %}
 </div>
 </body>


### PR DESCRIPTION
This is to make the SDK repos distributor-neutral.

The instructions for the correct mpad.js url are found in the devdocs for each distributor.